### PR TITLE
Fix preventDefault being ignored due to event listeners being passive

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   "peerDependencies": {
     "react": "^0.14 || ^15.0"
   },
-  "homepage": "https://github.com/jossmac/react-scrolllock#readme"
+  "homepage": "https://github.com/jossmac/react-scrolllock#readme",
+  "dependencies": {
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.8"
+  }
 }

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -12,15 +12,22 @@ var listenerOptions = { capture: false, passive: false };
 var ScrollLock = React.createClass({
 	propTypes: {
 		scrollTarget: React.PropTypes.object,
+		preventContentJumping: React.PropTypes.bool
+	},
+	defaultProps: {
+		preventContentJumping: true
 	},
 	componentDidMount: function () {
 		if (!canUseDom) return;
 
 		var scrollTarget = this.props.scrollTarget;
-		var scrollbarWidth = window.innerWidth - document.body.clientWidth; // 1.
 		var target = document.body;
 
-		target.style.paddingRight = scrollbarWidth + 'px';
+		if (this.props.preventContentJumping) {
+			var scrollbarWidth = window.innerWidth - document.body.clientWidth; // 1.
+
+			target.style.paddingRight = scrollbarWidth + 'px';
+		}
 		target.style.overflowY = 'hidden';
 
 		target.addEventListener('touchmove', preventTouchMove, listenerOptions); // 2.
@@ -36,7 +43,9 @@ var ScrollLock = React.createClass({
 		var scrollTarget = this.props.scrollTarget;
 		var target = document.body;
 
-		target.style.paddingRight = '';
+		if (this.props.preventContentJumping) {
+			target.style.paddingRight = '';
+		}
 		target.style.overflowY = '';
 
 		target.removeEventListener('touchmove', preventTouchMove, listenerOptions);

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -8,6 +8,7 @@ var React = require('react');
 	3. Allow scroll on provided target.
 */
 
+var listenerOptions = { capture: false, passive: false };
 var ScrollLock = React.createClass({
 	propTypes: {
 		scrollTarget: React.PropTypes.object,
@@ -22,11 +23,11 @@ var ScrollLock = React.createClass({
 		target.style.paddingRight = scrollbarWidth + 'px';
 		target.style.overflowY = 'hidden';
 
-		target.addEventListener('touchmove', preventTouchMove, false); // 2.
+		target.addEventListener('touchmove', preventTouchMove, listenerOptions); // 2.
 
 		if (scrollTarget) {
-			scrollTarget.addEventListener('touchstart', preventInertiaScroll, false); // 3.
-			scrollTarget.addEventListener('touchmove', allowTouchMove, false); // 3.
+			scrollTarget.addEventListener('touchstart', preventInertiaScroll, listenerOptions); // 3.
+			scrollTarget.addEventListener('touchmove', allowTouchMove, listenerOptions); // 3.
 		}
 	},
 	componentWillUnmount: function () {
@@ -38,11 +39,11 @@ var ScrollLock = React.createClass({
 		target.style.paddingRight = '';
 		target.style.overflowY = '';
 
-		target.removeEventListener('touchmove', preventTouchMove, false);
+		target.removeEventListener('touchmove', preventTouchMove, listenerOptions);
 
 		if (scrollTarget) {
-			scrollTarget.removeEventListener('touchstart', preventInertiaScroll, false);
-			scrollTarget.removeEventListener('touchmove', allowTouchMove, false);
+			scrollTarget.removeEventListener('touchstart', preventInertiaScroll, listenerOptions);
+			scrollTarget.removeEventListener('touchmove', allowTouchMove, listenerOptions);
 		}
 	},
 	render: function () {

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -1,4 +1,5 @@
-var React = require('react');
+var PropTypes = require('prop-types');
+var createClass = require('create-react-class');
 
 /*
 	NOTES
@@ -9,10 +10,10 @@ var React = require('react');
 */
 
 var listenerOptions = { capture: false, passive: false };
-var ScrollLock = React.createClass({
+var ScrollLock = createClass({
 	propTypes: {
-		scrollTarget: React.PropTypes.object,
-		preventContentJumping: React.PropTypes.bool
+		scrollTarget: PropTypes.object,
+		preventContentJumping: PropTypes.bool
 	},
 	defaultProps: {
 		preventContentJumping: true


### PR DESCRIPTION
Since Chrome 56, touch event listeners are passive by default, which means call to `preventDefault` would be ignored and warnings in console (see the screenshot). Details: https://www.chromestatus.com/features/5093566007214080

![screenshot 2017-03-28 15 19 38](https://cloud.githubusercontent.com/assets/742056/24407036/f9470d32-13c9-11e7-8ce5-18e503ea3529.png)

This PR makes the listeners not passive by setting it explicitly in options.