### PR TITLE
fix: use new package for proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "peerDependencies": {
     "react": "^0.14 || ^15.0"
   },
-  "homepage": "https://github.com/jossmac/react-scrolllock#readme"
+  "homepage": "https://github.com/jossmac/react-scrolllock#readme",
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  }
 }

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 
 /*
 	NOTES
@@ -10,7 +11,7 @@ var React = require('react');
 
 var ScrollLock = React.createClass({
 	propTypes: {
-		scrollTarget: React.PropTypes.object,
+		scrollTarget: PropTypes.object,
 	},
 	componentDidMount: function () {
 		if (!canUseDom) return;


### PR DESCRIPTION
Resolves warnings in new versions of React