### PR TITLE
fix: use new packages for deprecated APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/jossmac/react-scrolllock#readme",
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "peerDependencies": {
     "react": "^0.14 || ^15.0"
   },
-  "homepage": "https://github.com/jossmac/react-scrolllock#readme"
+  "homepage": "https://github.com/jossmac/react-scrolllock#readme",
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  }
 }

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var PropTypes = require('prop-types');
+var createClass = require('create-react-class');
 
 /*
 	NOTES
@@ -9,7 +10,7 @@ var PropTypes = require('prop-types');
 	3. Allow scroll on provided target.
 */
 
-var ScrollLock = React.createClass({
+var ScrollLock = createClass({
 	propTypes: {
 		scrollTarget: PropTypes.object,
 	},

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 
 /*
 	NOTES
@@ -10,7 +11,7 @@ var React = require('react');
 
 var ScrollLock = React.createClass({
 	propTypes: {
-		scrollTarget: React.PropTypes.object,
+		scrollTarget: PropTypes.object,
 	},
 	componentDidMount: function () {
 		if (!canUseDom) return;


### PR DESCRIPTION
PropTypes - moved to its own package, so I installed it.

Classes - I used create-react-class for this because I noticed there is no babel dependency here and I wanted to keep things light. I can refactor to newer syntax + Babel if you want