### PR TITLE
fix: Publish only the dist artefacts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
+__tests__
+config
 src
 examples
 .babelrc
 .gitignore
+index.js
 webpack.config.js


### PR DESCRIPTION
Since [adding the example page](https://github.com/jossmac/react-scrolllock/pull/20) the published artefacts contain broken code and `flow` is breaking as a result. The `__tests__` directory is being published which depends on `devDependencies` being installed and the `src` directory to be available.

This PR stops publishing the tests and it's config along with the unused entry point file.