### PR TITLE
change body position relative to static

### DIFF
--- a/src/withLockSheet.js
+++ b/src/withLockSheet.js
@@ -45,7 +45,7 @@ export default function withLockSheet(WrappedComponent: ComponentType<*>) {
       const styles = `body {
         box-sizing: border-box !important;
         overflow: hidden !important;
-        position: relative !important;
+        position: static !important;
         ${height ? `height: ${height}px !important;` : ''}
         ${paddingRight ? `padding-right: ${paddingRight}px !important;` : ''}
       }`;


### PR DESCRIPTION
Your library is great! However, we have a promo banner at the top of our site and position relative is breaking our component that uses ScrollLock. 
![image](https://user-images.githubusercontent.com/13875792/57040934-e3f09100-6c2e-11e9-83b4-4b8869770b26.png)
If I change this to `position: static` then it fixes the issue
![image](https://user-images.githubusercontent.com/13875792/57040977-05517d00-6c2f-11e9-82f6-300739b3975a.png)
I would love to keep using your library, so hopefully this is a fix that will work for you! 

Thanks!