### PR TITLE
Remove "react-node-resolver"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class Modal extends Component {
         <TouchScrollable>
           <ElementWithScrollableContent>...</ElementWithScrollableContent>
         </TouchScrollable>
-        
+
         // you can also toggle the lock based on some state.
         <ScrollLock isActive={this.state.lockScroll} />
       </div>
@@ -57,4 +57,4 @@ This is necessary because the `touchmove` event is explicitly cancelled &mdash; 
 
 | Property                 | Description                                    |
 | :----------------------- | :--------------------------------------------- |
-| children `element` | **Required** The element that can be scrolled. |
+| children `element` | `ref => element` | **Required** The element that can be scrolled. |

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -94,24 +94,29 @@ class App extends Component {
         {isTouchDevice() ? (
           <div style={{ position: 'relative' }}>
             <TouchScrollable>
-              <ScrollArea
-                height={this.scrollArea && this.scrollArea.clientHeight}
-                innerRef={this.getScrollArea}
-                onScroll={this.onScroll}
-              >
-                <p>
-                  Wrap an element in the <Code>TouchScrollable</Code> component
-                  if you need an area that supports scroll on mobile.
-                </p>
-                {isLocked ? (
+              {touchScrollableRef => (
+                <ScrollArea
+                  height={this.scrollArea && this.scrollArea.clientHeight}
+                  innerRef={val => {
+                    this.getScrollArea(val);
+                    touchScrollableRef(val);
+                  }}
+                  onScroll={this.onScroll}
+                >
                   <p>
-                    This is necessary because the <Code>touchmove</Code> event
-                    is explicitly cancelled &mdash; iOS doesn't observe{' '}
-                    <Code>{'overflow: hidden;'}</Code> when applied to the{' '}
-                    <Code>{'<body />'}</Code> element 😢
+                    Wrap an element in the <Code>TouchScrollable</Code> component
+                    if you need an area that supports scroll on mobile.
                   </p>
-                ) : null}
-              </ScrollArea>
+                  {isLocked ? (
+                    <p>
+                      This is necessary because the <Code>touchmove</Code> event
+                      is explicitly cancelled &mdash; iOS doesn't observe{' '}
+                      <Code>{'overflow: hidden;'}</Code> when applied to the{' '}
+                      <Code>{'<body />'}</Code> element 😢
+                    </p>
+                  ) : null}
+                </ScrollArea>
+              )}
             </TouchScrollable>
             {isLocked ? (
               <div

--- a/examples/src/styled.js
+++ b/examples/src/styled.js
@@ -1,5 +1,7 @@
 /* @jsx glam */
+
 import glam from 'glam';
+import { forwardRef } from 'react';
 
 const gutter = 15;
 
@@ -66,9 +68,9 @@ export const Icon = props => (
     {...props}
   />
 );
-export const ScrollArea = ({ height, innerRef, ...props }) => (
+export const ScrollArea = forwardRef(({ height, innerRef, ...props }, ref) => (
   <div
-    ref={innerRef}
+    ref={ref || innerRef}
     css={{
       backgroundColor: 'rgba(255, 255, 255, 0.5)',
       boxSizing: 'border-box',
@@ -91,7 +93,7 @@ export const ScrollArea = ({ height, innerRef, ...props }) => (
     }}
     {...props}
   />
-);
+));
 export const Title = props => (
   <h1
     css={{

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "precommit": "flow check && lint-staged"
   },
   "jest": {
-    "setupFiles": ["<rootDir>/config/setupPolyfills.js"],
+    "setupFiles": [
+      "<rootDir>/config/setupPolyfills.js"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/config/setupFramework.js"
   },
   "repository": {
@@ -29,10 +31,14 @@
     "url": "https://github.com/jossmac/react-scrolllock/issues"
   },
   "homepage": "https://jossmac.github.io/react-scrolllock",
-  "keywords": ["react", "scroll", "scroll-lock", "disable-scroll"],
+  "keywords": [
+    "react",
+    "scroll",
+    "scroll-lock",
+    "disable-scroll"
+  ],
   "dependencies": {
-    "exenv": "^1.2.2",
-    "react-node-resolver": "^2.0.1"
+    "exenv": "^1.2.2"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/src/ScrollLock.js
+++ b/src/ScrollLock.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { canUseDOM } from 'exenv';
 
-import { TouchScrollable } from './TouchScrollable';
+import { TouchScrollable, type ChildrenType } from './TouchScrollable';
 import withLockSheet from './withLockSheet';
 import withTouchListeners from './withTouchListeners';
 import { pipe } from './utils';
@@ -12,7 +12,7 @@ type Props = {
   // whether or not to replace the void left by now absent scrollbars with padding
   accountForScrollbars: boolean,
   // allow touch-scroll on this element
-  children?: Element<*>,
+  children?: ChildrenType,
   // whether or not the lock is active
   isActive: boolean,
 };

--- a/src/TouchScrollable.js
+++ b/src/TouchScrollable.js
@@ -1,13 +1,14 @@
 // @flow
-import React, { PureComponent, type Element } from 'react';
+import { cloneElement, PureComponent, type Element, type ElementRef } from 'react';
 import { canUseEventListeners } from 'exenv';
-import NodeResolver from 'react-node-resolver';
 
 import { allowTouchMove, preventInertiaScroll, listenerOptions } from './utils';
 
+export type ChildrenType = Element<*> | ElementRef<*> => Element<*>;
+
 type Props = {
   // allow touch-scroll on this element
-  children: Element<*>,
+  children: ChildrenType,
 };
 
 export class TouchScrollable extends PureComponent<Props> {
@@ -44,6 +45,10 @@ export class TouchScrollable extends PureComponent<Props> {
     );
   }
   render() {
-    return <NodeResolver innerRef={this.getScrollableArea} {...this.props} />;
+    const { children, ...rest } = this.props;
+
+    return typeof children === 'function'
+      ? children(this.getScrollableArea)
+      : cloneElement(children, { ref: this.getScrollableArea, ...rest });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,11 +6480,6 @@ react-dom@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-node-resolver@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-node-resolver/-/react-node-resolver-2.0.1.tgz#1f0cc83938bf590a1cf42006b23f6b8f68e7b886"
-  integrity sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA==
-
 react-prop-toggle@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-prop-toggle/-/react-prop-toggle-1.0.2.tgz#8b0b7e74653606b1427cfcf6c4eaa9198330568e"


### PR DESCRIPTION
This is a breaking change because we can no-longer assume safe ref resolution within consumer applications. `TouchScrollable` (and by composition `ScrollLock`) now support function or element children:

```tsx
type ChildrenType = Element<*> | ElementRef<*> => Element<*>
```

If a function is provided the ref is passed in as the only argument, otherwise we clone the child with the ref.

Resolves #41