### PR TITLE
FIX: Consider body margin while calculating scrollbar width

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,13 +11,13 @@ export const listenerOptions = {
 
 export function preventTouchMove(e) {
   e.preventDefault();
-  
+
   return false;
 }
 
 export function allowTouchMove(e) {
   const target = e.currentTarget;
-  
+
   if (target.scrollHeight > target.clientHeight) {
     e.stopPropagation();
     return true;
@@ -71,11 +71,13 @@ export const pipe = (...fns) => fns.reduce(pipeFns);
 export function getPadding() {
   if (!canUseDOM) return 0;
 
-  const currentPadding = parseInt(document.body.paddingRight, 10) || 0;
-  const clientWidth = document.body ? document.body.clientWidth : 0;
-  const adjustedPadding = window.innerWidth - clientWidth + currentPadding || 0;
+  const existingBodyPaddingRight =
+    parseInt(window.getComputedStyle(document.body).paddingRight, 10);
+  const scrollBarWidth =
+    window.innerWidth - document.documentElement.clientWidth;
+  const calculatedRightPadding = existingBodyPaddingRight + scrollBarWidth;
 
-  return adjustedPadding;
+  return calculatedRightPadding;
 }
 
 export function getWindowHeight(multiplier = 1) {


### PR DESCRIPTION
If body has a margin, then the scroll lock pushes the whole body (equal to margin value) to the left. This happens because body margin is not accounted while calculating a `padding-right` to negate scrollbar width in the page.

This fix —
- includes body margin while calculating the scrollbar negation `padding-right` value

To reproduce the issue in local, just add `body { margin: 100px }` in `index.css` file and you'll see the view getting pushed to the left when the scroll is locked.