### PR TITLE
Handle when elements they disappear without unmounting

### DIFF
--- a/src/TouchScrollable.js
+++ b/src/TouchScrollable.js
@@ -32,6 +32,7 @@ export class TouchScrollable extends PureComponent<Props> {
   }
   componentWillUnmount() {
     if (!canUseEventListeners) return;
+    if (!this.scrollableArea) return;
 
     this.scrollableArea.removeEventListener(
       'touchstart',


### PR DESCRIPTION
Posting it here just to check if anybody else had a problem with disappearing refs inside `TouchScrollable`.

An error with undefined `this` in `this.scrollableArea.removeEventListener` started happening when I've started using React Suspense with React Router DOM. In certain scenarios if you load a route with Suspense on it, `TouchScrollable` sometimes loses `this` value.

Not sure if there's something esoteric happening inside Suspense or there's something else - could not figure out. Was wondering if anybody else had a similar problem?

The diff here is just something that fixed my issue, but might be introducing some other problems later down the road.

Anyways - thanks for an amazing package!